### PR TITLE
[ FIX] 비교 사이즈 수동입력 시 컬럼순서 구분하여 저장

### DIFF
--- a/ownsize-express/prisma/schema.prisma
+++ b/ownsize-express/prisma/schema.prisma
@@ -44,17 +44,19 @@ model AllSizeBottom {
   isWidthOfBottom Boolean?
   isManual        Boolean?
   topOrBottom     Boolean?
+  manualInputNum  Int?
 }
 
 model AllSizeTop {
-  id           Int      @id @unique @default(autoincrement())
-  size         String?  @db.VarChar(10)
-  topLength    Int?
-  shoulder     Int?
-  chest        Int?
-  isWidthOfTop Boolean?
-  isManual     Boolean?
-  topOrBottom  Boolean?
+  id             Int      @id @unique @default(autoincrement())
+  size           String?  @db.VarChar(10)
+  topLength      Int?
+  shoulder       Int?
+  chest          Int?
+  isWidthOfTop   Boolean?
+  isManual       Boolean?
+  topOrBottom    Boolean?
+  manualInputNum Int?
 }
 
 model MySize {

--- a/ownsize-express/src/controller/extensionController.ts
+++ b/ownsize-express/src/controller/extensionController.ts
@@ -27,11 +27,12 @@ const toAllCloset = async (req: Request, res: Response) => {
 
 //* 비교 사이즈 수동 입력
 const inputSize = async (req: Request, res: Response) => {
-    const {isManual, topOrBottom, size, topLength, shoulder, chest, isWidthOfTop, bottomLength, waist, thigh, rise, hem, isWidthOfBottom} = req.body;
+    const {isManual, manualInputNum, topOrBottom, size, topLength, shoulder, chest, isWidthOfTop, bottomLength, waist, thigh, rise, hem, isWidthOfBottom} = req.body;
 
     const data = await extensionService
                         .inputSize(
                             isManual,
+                            manualInputNum,
                             topOrBottom,
                             size, 
                             topLength, 

--- a/ownsize-express/src/service/extensionService.ts
+++ b/ownsize-express/src/service/extensionService.ts
@@ -29,6 +29,7 @@ const toAllCloset = async (
 //* 비교 사이즈 수동 입력
 const inputSize = async (
     isManual: boolean,
+    manualInputNum: number,
     topOrBottom: number,
     size: string,
 
@@ -46,42 +47,23 @@ const inputSize = async (
 ) => {
     if (topOrBottom === 0) {
         const data = prisma.allSizeTop.createMany({
-            data: [
-                {
+            data: {
                 isManual: isManual,
-                size: size, 
-                topLength: topLength,
-                shoulder: shoulder,
-                chest: chest,
-                isWidthOfTop: isWidthOfTop,
-                },
-                { 
-                isManual: isManual,
+                manualInputNum: manualInputNum,
                 size: size,    
                 topLength: topLength,
                 shoulder: shoulder,
                 chest: chest,
                 isWidthOfTop: isWidthOfTop
-                }
-            ]
+            }
         })
         return data;
     }
     else if (topOrBottom === 1) {
         const data = prisma.allSizeBottom.createMany({
-            data: [
-                {
+            data: {
                 isManual: isManual,
-                size: size, 
-                bottomLength: bottomLength,
-                waist: waist,
-                thigh: thigh,
-                rise: rise,
-                hem: hem,
-                isWidthOfBottom: isWidthOfBottom
-                },
-                { 
-                isManual: isManual,
+                manualInputNum: manualInputNum,
                 size: size, 
                 bottomLength: bottomLength,
                 waist: waist,
@@ -90,7 +72,6 @@ const inputSize = async (
                 hem: hem,
                 isWidthOfBottom: isWidthOfBottom
                 }
-            ]
         })
         return data;
     }


### PR DESCRIPTION
## 🌱관련 이슈
Related to: #23

## 📌 설명
- 비교 사이즈 수동입력 시 컬럼순서 구분하여 저장 (한줄씩 요청하여 저장)

## ✅ 완료 목록
- 로컬 테스트 완료

## ❓ 궁금한 점 & 리뷰 포인트
