### PR TITLE
[FIX] 카테고리 생성시 이미지 body 에서 제외

### DIFF
--- a/ownsize-express/src/controller/categoryController.ts
+++ b/ownsize-express/src/controller/categoryController.ts
@@ -15,12 +15,11 @@ const getAllCategory = async (req: Request, res: Response) => {
 
 //* 카테고리 생성
 const createCategory = async (req: Request, res: Response) => {
-  const { categoryName, isPinCategory, image, userId } = req.body;
+  const { categoryName, isPinCategory, userId } = req.body;
 
   const data = await categoryService.createCategory(
     categoryName,
     isPinCategory,
-    image,
     +userId
   );
 

--- a/ownsize-express/src/service/categoryService.ts
+++ b/ownsize-express/src/service/categoryService.ts
@@ -49,7 +49,6 @@ const getAllCategory = async (userId: number) => {
 const createCategory = async (
   categoryName: string,
   isPinCategory: boolean,
-  image: string[],
   userId: number
 ) => {
   const data = await prisma.category.create({
@@ -57,7 +56,6 @@ const createCategory = async (
       userId: userId,
       categoryName: categoryName,
       isPinCategory: isPinCategory,
-      image: image,
     },
   });
 


### PR DESCRIPTION
## 🌱관련 이슈
Related to: #7 

## 📌 설명
- 카테고리 생성시 이미지 body 에서 안받아오는 걸로 변경(처음 생성할때는 카테고리 내에 아무것도 없기 때문)

## ✅ 완료 목록
- 로컬테스트 완료

## ❓ 궁금한 점 & 리뷰 포인트
