### PR TITLE
refresh token 추가

### DIFF
--- a/ownsize-express/prisma/schema.prisma
+++ b/ownsize-express/prisma/schema.prisma
@@ -12,8 +12,9 @@ model User {
   name          String?         @db.VarChar(10)
   email         String          @unique @db.VarChar(50)
   userImage     String?         @db.VarChar(500)
-  token         String?         @db.VarChar(500)
+  token         String?         @unique @db.VarChar(500)
   isUser        Boolean?        @default(true)
+  accessToken   String?         @db.VarChar(500)
   AllCloset     AllCloset[]
   AllSizeBottom AllSizeBottom[]
   AllSizeTop    AllSizeTop[]

--- a/ownsize-express/src/middlewares/auth.ts
+++ b/ownsize-express/src/middlewares/auth.ts
@@ -11,7 +11,6 @@ const jwt = require("jsonwebtoken");
 
 export default async (req: Request, res: Response, next: NextFunction) => {
   var accessToken = req.header("Authorization");
-  //var refreshToken = req.header("refreshToken");
 
   if (!accessToken) {
     // 로그인 안한 경우
@@ -22,16 +21,6 @@ export default async (req: Request, res: Response, next: NextFunction) => {
   const decoded = jwtHandler.verify(accessToken); //? jwtHandler에서 만들어둔 verify로 토큰 검사
 
   // refreshToken 디비에서 꺼내오는 코드 필요
-  //? 토큰 에러 분기 처리
-  if (decoded === tokenType.TOKEN_EXPIRED)
-    return res
-      .status(sc.UNAUTHORIZED)
-      .send(fail(sc.UNAUTHORIZED, rm.EXPIRED_TOKEN));
-  if (decoded === tokenType.TOKEN_INVALID)
-    return res
-      .status(sc.UNAUTHORIZED)
-      .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
-
   //? decode한 후 담겨있는 email을 꺼내옴
   const email: string = (decoded as JwtPayload).email;
   if (!email)
@@ -39,20 +28,30 @@ export default async (req: Request, res: Response, next: NextFunction) => {
       .status(sc.UNAUTHORIZED)
       .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
 
-  //? 얻어낸 email 을 Request Body 내 email 필드에 담고, 다음 미들웨어로 넘김( next() )
-  const result = await prisma.user.findUnique({
+  const data = await prisma.user.findUnique({
     where: {
       email: email,
     },
   });
 
-  if (!result) {
+  if (!data) {
     //해당 email이 없는 경우
     return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.NO_USER));
   }
-  var refreshToken = result.token;
+  var refreshToken = data.token;
+
+  if (!refreshToken) {
+    return res
+      .status(sc.UNAUTHORIZED)
+      .send(fail(sc.UNAUTHORIZED, rm.EMPTY_TOKEN));
+  }
 
   const decodedRefresh = jwtHandler.verify(refreshToken);
+
+  if (decoded === tokenType.TOKEN_INVALID)
+    return res
+      .status(sc.UNAUTHORIZED)
+      .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
 
   if (decoded === tokenType.TOKEN_EXPIRED) {
     if (decodedRefresh === tokenType.TOKEN_EXPIRED) {
@@ -83,64 +82,29 @@ export default async (req: Request, res: Response, next: NextFunction) => {
           expiresIn: "1h",
         }
       );
-
       req.body.userId = userData.id;
-      res.cookie("access", newAccessToken);
-      req.cookies.access = newAccessToken;
-      //next();
-      //! 클라한테 어떻게 전해주지?
+      req.body.accessToken = newAccessToken;
+      next();
     }
   } else {
-    // 여기부터는 access token 유효한 상태(만료되지 않음)
     if (decodedRefresh === tokenType.TOKEN_EXPIRED) {
       // case3: access token은 유효하지만, refresh token은 만료된 경우
       const newRefreshToken = jwt.sign({}, process.env.JWT_SECRET, {
         expiresIn: "14d",
       });
-      /**
-       * DB에 새로 발급된 refresh token 삽입하는 로직 (login과 유사)
-       */
-      //? decode한 후 담겨있는 email을 꺼내옴
-      const email: string = (decoded as JwtPayload).email;
-      if (!email)
-        return res
-          .status(sc.UNAUTHORIZED)
-          .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
-
+      // DB에 새로 발급된 refresh token 삽입
       const user = await prisma.user.update({
         where: { email: email },
         data: {
-          token: refreshToken,
+          token: newRefreshToken,
         },
       });
       req.body.userId = user.id;
-      res.cookie("refresh", newRefreshToken);
-      req.cookies.refresh = newRefreshToken;
-      //next();
+      req.body.refreshToken = newRefreshToken;
+      next();
     } else {
       // case4: access token과 refresh token 모두가 유효한 경우
-
-      //? decode한 후 담겨있는 email을 꺼내옴
-      const email: string = (decoded as JwtPayload).email;
-      if (!email)
-        return res
-          .status(sc.UNAUTHORIZED)
-          .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
-
-      //? 얻어낸 email 을 Request Body 내 email 필드에 담고, 다음 미들웨어로 넘김( next() )
-      const result = await prisma.user.findUnique({
-        where: {
-          email: email,
-        },
-      });
-
-      if (!result) {
-        //해당 email이 없는 경우
-        return res
-          .status(sc.UNAUTHORIZED)
-          .send(fail(sc.UNAUTHORIZED, rm.NO_USER));
-      }
-      req.body.userId = result.id;
+      req.body.userId = data.id;
       next();
     }
   }

--- a/ownsize-express/src/middlewares/auth.ts
+++ b/ownsize-express/src/middlewares/auth.ts
@@ -7,15 +7,21 @@ import jwtHandler from "./jwtHandler";
 import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
 
+const jwt = require("jsonwebtoken");
+
 export default async (req: Request, res: Response, next: NextFunction) => {
-  var token = req.header("Authorization");
-  if (!token) {
+  var accessToken = req.header("Authorization");
+  //var refreshToken = req.header("refreshToken");
+
+  if (!accessToken) {
+    // 로그인 안한 경우
     return res
       .status(sc.UNAUTHORIZED)
       .send(fail(sc.UNAUTHORIZED, rm.EMPTY_TOKEN));
   }
-  const decoded = jwtHandler.verify(token); //? jwtHandler에서 만들어둔 verify로 토큰 검사
+  const decoded = jwtHandler.verify(accessToken); //? jwtHandler에서 만들어둔 verify로 토큰 검사
 
+  // refreshToken 디비에서 꺼내오는 코드 필요
   //? 토큰 에러 분기 처리
   if (decoded === tokenType.TOKEN_EXPIRED)
     return res
@@ -44,8 +50,98 @@ export default async (req: Request, res: Response, next: NextFunction) => {
     //해당 email이 없는 경우
     return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.NO_USER));
   }
-  //console.log("email: ", email);
-  //console.log("userId: ", result.id);
-  req.body.userId = result.id;
-  next();
+  var refreshToken = result.token;
+
+  const decodedRefresh = jwtHandler.verify(refreshToken);
+
+  if (decoded === tokenType.TOKEN_EXPIRED) {
+    if (decodedRefresh === tokenType.TOKEN_EXPIRED) {
+      // case1: access token과 refresh token 모두가 만료된 경우
+      return res
+        .status(sc.UNAUTHORIZED)
+        .send(fail(sc.UNAUTHORIZED, rm.EXPIRED_TOKEN));
+    } else {
+      // case2: access token은 만료됐지만, refresh token은 유효한 경우
+      const userData = await prisma.user.findUnique({
+        where: {
+          token: refreshToken,
+        },
+      });
+      if (!userData) {
+        //해당 refreshToken 맞는 유저 없는 경우
+        return res
+          .status(sc.UNAUTHORIZED)
+          .send(fail(sc.UNAUTHORIZED, rm.NO_USER));
+      }
+
+      const newAccessToken = jwt.sign(
+        {
+          email: userData.email,
+        },
+        process.env.JWT_SECRET,
+        {
+          expiresIn: "1h",
+        }
+      );
+
+      req.body.userId = userData.id;
+      res.cookie("access", newAccessToken);
+      req.cookies.access = newAccessToken;
+      //next();
+      //! 클라한테 어떻게 전해주지?
+    }
+  } else {
+    // 여기부터는 access token 유효한 상태(만료되지 않음)
+    if (decodedRefresh === tokenType.TOKEN_EXPIRED) {
+      // case3: access token은 유효하지만, refresh token은 만료된 경우
+      const newRefreshToken = jwt.sign({}, process.env.JWT_SECRET, {
+        expiresIn: "14d",
+      });
+      /**
+       * DB에 새로 발급된 refresh token 삽입하는 로직 (login과 유사)
+       */
+      //? decode한 후 담겨있는 email을 꺼내옴
+      const email: string = (decoded as JwtPayload).email;
+      if (!email)
+        return res
+          .status(sc.UNAUTHORIZED)
+          .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
+
+      const user = await prisma.user.update({
+        where: { email: email },
+        data: {
+          token: refreshToken,
+        },
+      });
+      req.body.userId = user.id;
+      res.cookie("refresh", newRefreshToken);
+      req.cookies.refresh = newRefreshToken;
+      //next();
+    } else {
+      // case4: access token과 refresh token 모두가 유효한 경우
+
+      //? decode한 후 담겨있는 email을 꺼내옴
+      const email: string = (decoded as JwtPayload).email;
+      if (!email)
+        return res
+          .status(sc.UNAUTHORIZED)
+          .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
+
+      //? 얻어낸 email 을 Request Body 내 email 필드에 담고, 다음 미들웨어로 넘김( next() )
+      const result = await prisma.user.findUnique({
+        where: {
+          email: email,
+        },
+      });
+
+      if (!result) {
+        //해당 email이 없는 경우
+        return res
+          .status(sc.UNAUTHORIZED)
+          .send(fail(sc.UNAUTHORIZED, rm.NO_USER));
+      }
+      req.body.userId = result.id;
+      next();
+    }
+  }
 };

--- a/ownsize-express/src/service/authService.ts
+++ b/ownsize-express/src/service/authService.ts
@@ -6,22 +6,29 @@ const jwt = require("jsonwebtoken");
 
 //* 회원가입 및 로그인
 const register = async (email: string, name: string) => {
-  const token = jwt.sign(
+  const refreshToken = jwt.sign({}, process.env.JWT_SECRET, {
+    expiresIn: "14d",
+  });
+
+  const accessToken = jwt.sign(
     {
       email: email,
     },
-    process.env.JWT_SECRET
+    process.env.JWT_SECRET,
+    {
+      expiresIn: "1h",
+    }
   );
 
   // DB에 저장된 사람이라면 DB에 JWT token만 업데이트를 해주고,
   // DB에 없다면 JWT 토큰을 만들어주고 돌려준다.
   const user = await prisma.user.upsert({
     where: { email: email },
-    update: { token: token }, //있으면 업데이트
+    update: { token: refreshToken }, //있으면 업데이트
     create: {
       name: name,
       email: email,
-      token: token,
+      token: refreshToken,
     }, //없으면 만듦
   });
 
@@ -30,27 +37,11 @@ const register = async (email: string, name: string) => {
     return null;
   }
 
-  //유저 등록 시 해당 유저의 mysize 입력칸 생성
-  // await prisma.mySize.create({
-  //   data: {
-  //     userId: user.id,
-  //     topLength: null,
-  //     shoulder: null,
-  //     chest: null,
-  //     isWidthOfTop: null,
-  //     bottomLength: null,
-  //     waist: null,
-  //     thigh: null,
-  //     rise: null,
-  //     hem: null,
-  //     isWidthOfBottom: null,
-  //   },
-  // });
-
   // 생성된 토큰과 userId를 리턴
   const data = {
     userId: user.id,
-    token: token,
+    refreshToken: refreshToken,
+    accessToken: accessToken,
   };
   return data;
 };

--- a/ownsize-express/src/service/pageService.ts
+++ b/ownsize-express/src/service/pageService.ts
@@ -63,4 +63,7 @@ const pageService = {
   getRecCount,
 };
 
+module.exports = {
+  getMyPage: getMyPage,
+};
 export default pageService;


### PR DESCRIPTION
## 🌱관련 이슈
Related to: #

## 📌 설명
- 회원가입 및 로그인 시 엑세스 토큰과 리프레시 토큰 생성, 리프레시 토큰은 디비에 저장 (authService)
- auth 미들웨어에서 권한 확인시, 토큰 만료됐는지 확인하는 과정 추가(case 1-4 나눠져 있음) 

## ✅ 완료 목록
- 테스트 안함

## ❓ 궁금한 점 & 리뷰 포인트
case 1: access token과 refresh token 모두가 만료된 경우
case 2: access token은 만료됐지만, refresh token은 유효한 경우
case 3: access token은 유효하지만, refresh token은 만료된 경우
case 4: access token과 refresh token 모두가 유효한 경우

디비에서 token이 리프레시토큰임. 
accessToken은 잠깐 무시하세요 나중에 지울 가능성이 높음