### PR TITLE
토큰 재발급 API 

### DIFF
--- a/ownsize-express/prisma/schema.prisma
+++ b/ownsize-express/prisma/schema.prisma
@@ -14,7 +14,6 @@ model User {
   userImage     String?         @db.VarChar(500)
   token         String?         @unique @db.VarChar(500)
   isUser        Boolean?        @default(true)
-  accessToken   String?         @db.VarChar(500)
   AllCloset     AllCloset[]
   AllSizeBottom AllSizeBottom[]
   AllSizeTop    AllSizeTop[]
@@ -26,7 +25,7 @@ model AllCloset {
   id                 Int                  @id(map: "Archive_pkey") @unique(map: "Archive_id_key") @default(autoincrement())
   userId             Int                  @default(autoincrement())
   image              String?              @db.VarChar(500)
-  productName        String?              @db.VarChar(36)
+  productName        String?              @db.VarChar(100)
   size               String?              @db.VarChar(10)
   memo               String?              @db.VarChar(50)
   isRecommend        Boolean?

--- a/ownsize-express/src/constants/responseMessage.ts
+++ b/ownsize-express/src/constants/responseMessage.ts
@@ -28,7 +28,7 @@ export default {
   // 토큰
   CREATE_TOKEN_SUCCESS: "토큰 재발급 성공",
   EXPIRED_TOKEN: "토큰이 만료되었습니다.",
-  EXPIRED_ALL_TOKEN: "모든 토큰이 만료되었습니다.",
+  EXPIRED_ALL_TOKEN: "모든 토큰이 만료되었습니다. 재로그인을 진행해주세요.",
   INVALID_TOKEN: "유효하지 않은 토큰입니다.",
   VALID_TOKEN: "유효한 토큰입니다.",
   EMPTY_TOKEN: "토큰 값이 없습니다.",

--- a/ownsize-express/src/controller/authController.ts
+++ b/ownsize-express/src/controller/authController.ts
@@ -19,8 +19,24 @@ const register = async (req: Request, res: Response) => {
   return res.status(sc.OK).send(success(sc.OK, rm.SIGNIN_SUCCESS, data)); // 로그인 성공
 };
 
+//* 엑세스 토큰 재발급
+const newToken = async (req: Request, res: Response) => {
+  const { userId } = req.body;
+
+  const data = await authService.newToken(+userId);
+
+  if (!data) {
+    //엑세스 토큰 안만들어진 경우
+    return res
+      .status(sc.NOT_FOUND)
+      .send(fail(sc.NOT_FOUND, rm.EXPIRED_ALL_TOKEN)); //access, refresh 둘다 만료된 경우->재로그인
+  }
+  return res.status(sc.OK).send(success(sc.OK, rm.CREATE_TOKEN_SUCCESS, data)); // 엑세스 토큰 재발급 성공
+};
+
 const authController = {
   register,
+  newToken,
 };
 
 export default authController;

--- a/ownsize-express/src/middlewares/auth.ts
+++ b/ownsize-express/src/middlewares/auth.ts
@@ -83,7 +83,8 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         }
       );
       req.body.userId = userData.id;
-      req.body.accessToken = newAccessToken;
+      //req.body.accessToken = newAccessToken;
+      res.send({ token: newAccessToken });
       next();
     }
   } else {
@@ -100,7 +101,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         },
       });
       req.body.userId = user.id;
-      req.body.refreshToken = newRefreshToken;
+      //req.body.refreshToken = newRefreshToken;
       next();
     } else {
       // case4: access token과 refresh token 모두가 유효한 경우

--- a/ownsize-express/src/middlewares/auth.ts
+++ b/ownsize-express/src/middlewares/auth.ts
@@ -7,20 +7,26 @@ import jwtHandler from "./jwtHandler";
 import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
 
-const jwt = require("jsonwebtoken");
-
 export default async (req: Request, res: Response, next: NextFunction) => {
-  var accessToken = req.header("Authorization");
-
-  if (!accessToken) {
-    // 로그인 안한 경우
+  var token = req.header("Authorization");
+  if (!token) {
     return res
       .status(sc.UNAUTHORIZED)
       .send(fail(sc.UNAUTHORIZED, rm.EMPTY_TOKEN));
   }
-  const decoded = jwtHandler.verify(accessToken); //? jwtHandler에서 만들어둔 verify로 토큰 검사
+  const decoded = jwtHandler.verify(token); //? jwtHandler에서 만들어둔 verify로 토큰 검사
 
-  // refreshToken 디비에서 꺼내오는 코드 필요
+  //? 토큰 에러 분기 처리
+  //401 응답->토큰재발급 API 올것
+  if (decoded === tokenType.TOKEN_EXPIRED)
+    return res
+      .status(sc.UNAUTHORIZED)
+      .send(fail(sc.UNAUTHORIZED, rm.EXPIRED_TOKEN));
+  if (decoded === tokenType.TOKEN_INVALID)
+    return res
+      .status(sc.UNAUTHORIZED)
+      .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
+
   //? decode한 후 담겨있는 email을 꺼내옴
   const email: string = (decoded as JwtPayload).email;
   if (!email)
@@ -28,85 +34,17 @@ export default async (req: Request, res: Response, next: NextFunction) => {
       .status(sc.UNAUTHORIZED)
       .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
 
-  const data = await prisma.user.findUnique({
+  //? 얻어낸 email 을 Request Body 내 email 필드에 담고, 다음 미들웨어로 넘김( next() )
+  const result = await prisma.user.findUnique({
     where: {
       email: email,
     },
   });
 
-  if (!data) {
+  if (!result) {
     //해당 email이 없는 경우
     return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.NO_USER));
   }
-  var refreshToken = data.token;
-
-  if (!refreshToken) {
-    return res
-      .status(sc.UNAUTHORIZED)
-      .send(fail(sc.UNAUTHORIZED, rm.EMPTY_TOKEN));
-  }
-
-  const decodedRefresh = jwtHandler.verify(refreshToken);
-
-  if (decoded === tokenType.TOKEN_INVALID)
-    return res
-      .status(sc.UNAUTHORIZED)
-      .send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
-
-  if (decoded === tokenType.TOKEN_EXPIRED) {
-    if (decodedRefresh === tokenType.TOKEN_EXPIRED) {
-      // case1: access token과 refresh token 모두가 만료된 경우
-      return res
-        .status(sc.UNAUTHORIZED)
-        .send(fail(sc.UNAUTHORIZED, rm.EXPIRED_TOKEN));
-    } else {
-      // case2: access token은 만료됐지만, refresh token은 유효한 경우
-      const userData = await prisma.user.findUnique({
-        where: {
-          token: refreshToken,
-        },
-      });
-      if (!userData) {
-        //해당 refreshToken 맞는 유저 없는 경우
-        return res
-          .status(sc.UNAUTHORIZED)
-          .send(fail(sc.UNAUTHORIZED, rm.NO_USER));
-      }
-
-      const newAccessToken = jwt.sign(
-        {
-          email: userData.email,
-        },
-        process.env.JWT_SECRET,
-        {
-          expiresIn: "1h",
-        }
-      );
-      req.body.userId = userData.id;
-      //req.body.accessToken = newAccessToken;
-      res.send({ token: newAccessToken });
-      next();
-    }
-  } else {
-    if (decodedRefresh === tokenType.TOKEN_EXPIRED) {
-      // case3: access token은 유효하지만, refresh token은 만료된 경우
-      const newRefreshToken = jwt.sign({}, process.env.JWT_SECRET, {
-        expiresIn: "14d",
-      });
-      // DB에 새로 발급된 refresh token 삽입
-      const user = await prisma.user.update({
-        where: { email: email },
-        data: {
-          token: newRefreshToken,
-        },
-      });
-      req.body.userId = user.id;
-      //req.body.refreshToken = newRefreshToken;
-      next();
-    } else {
-      // case4: access token과 refresh token 모두가 유효한 경우
-      req.body.userId = data.id;
-      next();
-    }
-  }
+  req.body.userId = result.id;
+  next();
 };

--- a/ownsize-express/src/router/authRouter.ts
+++ b/ownsize-express/src/router/authRouter.ts
@@ -1,9 +1,13 @@
 import { Router } from "express";
 import { authController } from "../controller";
+import { auth } from "../middlewares";
 
 const router: Router = Router();
 
 //* 회원가입 및 로그인 POST /auth
 router.post("/", authController.register);
+
+//* 엑세스 토큰 재발급 GET /auth/token
+router.get("/token", auth, authController.newToken);
 
 export default router;

--- a/ownsize-express/src/service/authService.ts
+++ b/ownsize-express/src/service/authService.ts
@@ -1,4 +1,6 @@
 import { PrismaClient } from "@prisma/client";
+import jwtHandler from "../middlewares/jwtHandler";
+import tokenType from "../constants/tokenType";
 const prisma = new PrismaClient();
 require("dotenv").config();
 
@@ -46,8 +48,48 @@ const register = async (email: string, name: string) => {
   return data;
 };
 
+//* 엑세스 토큰 재발급 (access, refresh 둘다 만료됐을때는 실패 응답 보냄)
+const newToken = async (userId: number) => {
+  // DB에 저장된 refresh 토큰 확인
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+  });
+
+  if (!user) {
+    console.log("user error");
+    return null;
+  }
+  if (!user.token) {
+    console.log("user refresh token empty");
+    return null;
+  }
+
+  const decodedRefresh = jwtHandler.verify(user.token);
+  if (decodedRefresh === tokenType.TOKEN_EXPIRED) {
+    //재로그인 필요한 경우
+    return null;
+  } else {
+    //refresh token 유효하니까 access token 재발급
+    const newAccessToken = jwt.sign(
+      {
+        email: user.email,
+      },
+      process.env.JWT_SECRET,
+      {
+        expiresIn: "1h",
+      }
+    );
+    const data = {
+      userId: user.id,
+      token: newAccessToken,
+    };
+    return data;
+  }
+};
+
 const authService = {
   register,
+  newToken,
 };
 
 export default authService;

--- a/ownsize-express/src/service/authService.ts
+++ b/ownsize-express/src/service/authService.ts
@@ -40,8 +40,8 @@ const register = async (email: string, name: string) => {
   // 생성된 토큰과 userId를 리턴
   const data = {
     userId: user.id,
-    refreshToken: refreshToken,
-    accessToken: accessToken,
+    //refreshToken: refreshToken,
+    token: accessToken,
   };
   return data;
 };


### PR DESCRIPTION
## 🌱관련 이슈
Related to: #

## 📌 설명
- 기존에 미들웨어에서 토큰 만료 확인 후 바로 재발급해주는 방식말고, 그냥 토큰 만료되면 401 응답 보낸 이후에 클라 쪽에서 엑세스 토큰 재발급 API 요청하는 방식으로 변경

## ✅ 완료 목록
- 로컬테스트는 안함, 웹쪽이랑 테스트 필요

## ❓ 궁금한 점 & 리뷰 포인트
- 재발급 요청시 refresh token 만료되지 않았으면 access token 재발급해서 응답으로 넘겨주고, 만약 refresh token이 만료되었으면 오류 응답을 줘서 웹쪽에서 사용자 재로그인 하도록 함
- 미들웨어 auth.ts는 이전에 쓰던 코드로 되돌림