### PR TITLE
[FIX] 핀 고정 최신순 정렬

### DIFF
--- a/ownsize-express/prisma/schema.prisma
+++ b/ownsize-express/prisma/schema.prisma
@@ -35,6 +35,7 @@ model AllCloset {
   productUrl         String?              @db.VarChar(500)
   faviconUrl         String?              @db.VarChar(500)
   createdAt          String?              @db.VarChar(20)
+  updateAt           String?              @db.VarChar(20)
   User               User                 @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "allcloset_user_id_fk")
   AllCloset_Category AllCloset_Category[]
 }

--- a/ownsize-express/prisma/schema.prisma
+++ b/ownsize-express/prisma/schema.prisma
@@ -93,17 +93,19 @@ model Category {
   isPinCategory      Boolean?
   image              String[]             @db.VarChar
   userId             Int                  @default(autoincrement())
+  updateCategoryAt   String?              @db.VarChar(20)
   AllCloset_Category AllCloset_Category[]
   User               User                 @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "category_user_id_fk")
 }
 
 model AllCloset_Category {
-  id         Int       @id @unique @default(autoincrement())
-  productId  Int       @default(autoincrement())
-  categoryId Int       @default(autoincrement())
-  isInPin    Boolean?  @default(false)
-  AllCloset  AllCloset @relation(fields: [productId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "allcloset_category_allcloset_id_fk")
-  Category   Category  @relation(fields: [categoryId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "allcloset_category_category_id_fk")
+  id            Int       @id @unique @default(autoincrement())
+  productId     Int       @default(autoincrement())
+  categoryId    Int       @default(autoincrement())
+  isInPin       Boolean?  @default(false)
+  updateInPinAt String?   @db.VarChar(20)
+  AllCloset     AllCloset @relation(fields: [productId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "allcloset_category_allcloset_id_fk")
+  Category      Category  @relation(fields: [categoryId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "allcloset_category_category_id_fk")
 }
 
 model Recommend {

--- a/ownsize-express/src/service/categoryService.ts
+++ b/ownsize-express/src/service/categoryService.ts
@@ -71,15 +71,32 @@ const updateCategory = async (
   categoryName?: string,
   isPinCategory?: boolean
 ) => {
-  const data = await prisma.category.updateMany({
+  await prisma.category.updateMany({
     where: {
       AND: [{ id: categoryId }, { userId: userId }],
     },
     data: {
       categoryName: categoryName,
       isPinCategory: isPinCategory,
+      updateCategoryAt: String(Date.now())
     },
   });
+
+  const data = await prisma.category.findMany({
+    where: {
+      AND: [{ id: categoryId }, { userId: userId }],
+    },
+    select: {
+      id: true,
+      categoryName: true,
+      isPinCategory: true,
+      updateCategoryAt: true
+    },
+    orderBy: {
+      updateCategoryAt: 'desc'
+    }
+  });
+  
   return data;
 };
 
@@ -154,13 +171,27 @@ const pinItem = async (
   productId: number,
   isInPin: boolean
 ) => {
-  const data = await prisma.allCloset_Category.updateMany({
+  await prisma.allCloset_Category.updateMany({
     where: {
       AND: [{ categoryId: categoryId }, { productId: productId }],
     },
     data: {
       isInPin: isInPin,
+      updateInPinAt: String(Date.now())
     },
+  });
+
+  const data = await prisma.allCloset_Category.findMany({
+    where: {
+      AND: [{ categoryId: categoryId }, { productId: productId }],
+    },
+    select: {
+      isInPin: true,
+      updateInPinAt: true
+    },
+    orderBy: {
+      updateInPinAt: 'desc'
+    }
   });
 
   return data;

--- a/ownsize-express/src/service/closetService.ts
+++ b/ownsize-express/src/service/closetService.ts
@@ -20,7 +20,7 @@ const updateCloset = async (
   size?: string,
   memo?: string,
   isPin?: boolean,
-  isRecommend?: boolean
+  isRecommend?: boolean,
 ) => {
   await prisma.allCloset.updateMany({
     where: {
@@ -31,7 +31,8 @@ const updateCloset = async (
       size: size,
       memo: memo,
       isPin: isPin,
-      isRecommend: isRecommend
+      isRecommend: isRecommend,
+      updateAt: String(Date.now())
     },
   });
 
@@ -47,8 +48,12 @@ const updateCloset = async (
       mallName: true,
       isRecommend: true,
       isPin: true,
+      updateAt: true
     },
-  });
+    orderBy: {
+      updateAt: 'desc'
+    }
+  }); 
 
   return data;
 };


### PR DESCRIPTION
## 🌱관련 이슈
Related to: #4 

## 📌 설명
- 전체 옷장 핀 고정 시 가장 최근 고정 item이 맨 앞으로 고정됨
- 카테고리 핀, 카테고리 내부 요소 핀도 동일

## ✅ 완료 목록
- 로컬 테스트 완료

## ❓ 궁금한 점 & 리뷰 포인트
- updateAt, updateCategoryAt, updataInPinAt 세 요소를 사용하여 수정 시기를 string값으로 내림차순으로 넘겨주므로 핀 최신순 정렬 가능
- 나머지 옷들은 기존의 id 기반 최신순 정렬로 클라단에서 해결!